### PR TITLE
enable cleanup pass by default and update tests

### DIFF
--- a/lib/Frontends/ZIR/Driver.cpp
+++ b/lib/Frontends/ZIR/Driver.cpp
@@ -64,9 +64,8 @@ static cl::opt<std::string>
 // They are defined with external storage to avoid having to wrap
 // the code that uses them in preprocessor checks too
 bool DisableMultiThreadingFlag = false;
-// Disabled by default until LLZK-177 is resolved
-bool DisableCleanupPassesFlag = true;
-bool DisableCastReconciliationFlag = true;
+bool DisableCleanupPassesFlag = false;
+bool DisableCastReconciliationFlag = false;
 
 #ifndef NDEBUG
 static cl::opt<bool, true> DisableMultiThreading(

--- a/tests/lit/zir/blocks/block_members.zir
+++ b/tests/lit/zir/blocks/block_members.zir
@@ -18,10 +18,10 @@ component Bar() {
   f.values[0].x
 
 // CHECK-LABEL: func @compute() -> !llzk.struct<@Bar<[]>> {
+// CHECK: %[[C:[0-9a-zA-Z_\.]+]] = constfelt  0
 // CHECK: %[[T0:[0-9a-zA-Z_\.]+]] = new_struct : <@Bar<[]>>
 // CHECK: %[[T1:[0-9a-zA-Z_\.]+]] = readf %[[T0]][@f] : <@Bar<[]>>, !llzk.struct<@Foo<[]>>
 // CHECK: %[[T2:[0-9a-zA-Z_\.]+]] = readf %[[T1]][@values] : <@Foo<[]>>, !llzk.array<7 x !llzk.struct<@block$<[]>>>
-// CHECK: %[[C:[0-9a-zA-Z_\.]+]] = constfelt  0
 // CHECK: %[[T3:[0-9a-zA-Z_\.]+]] = toindex %[[C]]
 // CHECK: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[T2]][%[[T3]]] : <7 x !llzk.struct<@block$<[]>>>, !llzk.struct<@block$<[]>>
 // CHECK: %[[T5:[0-9a-zA-Z_\.]+]] = readf %[[T4]][@x] : <@block$<[]>>, !llzk.struct<@Reg<[]>>

--- a/tests/lit/zir/extval/add_ext.zir
+++ b/tests/lit/zir/extval/add_ext.zir
@@ -16,14 +16,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
 // CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = add %[[T0]], %[[T4]] : !llzk.felt, !llzk.felt
 // CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = add %[[T1]], %[[T5]] : !llzk.felt, !llzk.felt
@@ -45,22 +41,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
-
-// CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = add %[[T0]], %[[T4]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = add %[[T1]], %[[T5]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T10:[0-9a-zA-Z_\.]+]] = add %[[T2]], %[[T6]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T11:[0-9a-zA-Z_\.]+]] = add %[[T3]], %[[T7]] : !llzk.felt, !llzk.felt
-
-// CHECK-DAG: %[[T12:[0-9a-zA-Z_\.]+]] = new_array %[[T8]], %[[T9]], %[[T10]], %[[T11]] : <4 x !llzk.felt>
+// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
   ExtAdd(x, y)
 }
-

--- a/tests/lit/zir/extval/array_of_extval.zir
+++ b/tests/lit/zir/extval/array_of_extval.zir
@@ -16,14 +16,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
 // CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = add %[[T0]], %[[T4]] : !llzk.felt, !llzk.felt
 // CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = add %[[T1]], %[[T5]] : !llzk.felt, !llzk.felt
@@ -32,23 +28,15 @@ component Foo(x: ExtVal, y: ExtVal) {
 
 // CHECK-DAG: %[[T12:[0-9a-zA-Z_\.]+]] = new_array %[[T8]], %[[T9]], %[[T10]], %[[T11]] : <4 x !llzk.felt>
 
-// CHECK-DAG: %[[C8:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C9:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C10:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C11:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T13:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C8]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T14:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C9]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T15:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C10]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T16:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C11]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T13:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T14:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T15:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T16:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C12:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C13:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C14:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C15:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T17:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C12]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T18:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C13]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T19:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C14]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T20:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C15]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T17:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T18:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T19:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T20:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
 // CHECK-DAG: %[[T21:[0-9a-zA-Z_\.]+]] = sub %[[T13]], %[[T17]] : !llzk.felt, !llzk.felt
 // CHECK-DAG: %[[T22:[0-9a-zA-Z_\.]+]] = sub %[[T14]], %[[T18]] : !llzk.felt, !llzk.felt
@@ -57,10 +45,8 @@ component Foo(x: ExtVal, y: ExtVal) {
 
 // CHECK-DAG: %[[T25:[0-9a-zA-Z_\.]+]] = new_array %[[T21]], %[[T22]], %[[T23]], %[[T24]] : <4 x !llzk.felt>
 // CHECK-DAG: %[[T26:[0-9a-zA-Z_\.]+]] = new_array : <2,4 x !llzk.felt>
-// CHECK-DAG: %[[I0:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: insertarr %[[T26]][%[[I0]]] = %[[T12]] : <2,4 x !llzk.felt>, <4 x !llzk.felt>
-// CHECK-DAG: %[[I1:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: insertarr %[[T26]][%[[I1]]] = %[[T25]] : <2,4 x !llzk.felt>, <4 x !llzk.felt>
+// CHECK-DAG: insertarr %[[T26]][%[[C0]]] = %[[T12]] : <2,4 x !llzk.felt>, <4 x !llzk.felt>
+// CHECK-DAG: insertarr %[[T26]][%[[C1]]] = %[[T25]] : <2,4 x !llzk.felt>, <4 x !llzk.felt>
 
 // CHECK-DAG: %[[SELF:[0-9a-zA-Z_\.]+]] = new_struct : <@Foo<[]>>
 // CHECK-DAG: writef %[[SELF]][@"$super"] = %[[T26]] : <@Foo<[]>>, !llzk.array<2,4 x !llzk.felt>
@@ -78,51 +64,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
-
-// CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = add %[[T0]], %[[T4]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = add %[[T1]], %[[T5]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T10:[0-9a-zA-Z_\.]+]] = add %[[T2]], %[[T6]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T11:[0-9a-zA-Z_\.]+]] = add %[[T3]], %[[T7]] : !llzk.felt, !llzk.felt
-
-// CHECK-DAG: %[[T12:[0-9a-zA-Z_\.]+]] = new_array %[[T8]], %[[T9]], %[[T10]], %[[T11]] : <4 x !llzk.felt>
-
-// CHECK-DAG: %[[C8:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C9:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C10:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C11:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T13:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C8]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T14:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C9]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T15:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C10]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T16:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C11]]] : <4 x !llzk.felt>, !llzk.felt
-
-// CHECK-DAG: %[[C12:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C13:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C14:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C15:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T17:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C12]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T18:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C13]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T19:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C14]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T20:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C15]]] : <4 x !llzk.felt>, !llzk.felt
-
-// CHECK-DAG: %[[T21:[0-9a-zA-Z_\.]+]] = sub %[[T13]], %[[T17]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T22:[0-9a-zA-Z_\.]+]] = sub %[[T14]], %[[T18]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T23:[0-9a-zA-Z_\.]+]] = sub %[[T15]], %[[T19]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T24:[0-9a-zA-Z_\.]+]] = sub %[[T16]], %[[T20]] : !llzk.felt, !llzk.felt
-
-// CHECK-DAG: %[[T25:[0-9a-zA-Z_\.]+]] = new_array %[[T21]], %[[T22]], %[[T23]], %[[T24]] : <4 x !llzk.felt>
-// CHECK-DAG: %[[T26:[0-9a-zA-Z_\.]+]] = new_array : <2,4 x !llzk.felt>
-// CHECK-DAG: %[[I0:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: insertarr %[[T26]][%[[I0]]] = %[[T12]] : <2,4 x !llzk.felt>, <4 x !llzk.felt>
-// CHECK-DAG: %[[I1:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: insertarr %[[T26]][%[[I1]]] = %[[T25]] : <2,4 x !llzk.felt>, <4 x !llzk.felt>
+// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
   [
     ExtAdd(x, y),

--- a/tests/lit/zir/extval/make_ext.zir
+++ b/tests/lit/zir/extval/make_ext.zir
@@ -15,10 +15,5 @@ component Foo() {
 
 // CHECK-LABEL: func @constrain(%arg0: !llzk.struct<@Foo<[]>>) {
 
-// CHECK-DAG: %[[C0:[0-9a-zA-Z_\.]+]] = constfelt  0
-// CHECK-DAG: %[[C1:[0-9a-zA-Z_\.]+]] = constfelt  10
-
-// CHECK-DAG: %[[T10:[0-9a-zA-Z_\.]+]] = new_array %[[C1]], %[[C0]], %[[C0]], %[[C0]] : <4 x !llzk.felt>
-
   x := MakeExt(10);
 }

--- a/tests/lit/zir/extval/mul_ext.zir
+++ b/tests/lit/zir/extval/mul_ext.zir
@@ -18,14 +18,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[A2:[0-9a-zA-Z_\.]+]] = readarr %[[A]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[A3:[0-9a-zA-Z_\.]+]] = readarr %[[A]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[B0:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[B1:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[B2:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[B3:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B0:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B1:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B2:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B3:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
 // CHECK-DAG: %[[BETA:[0-9a-zA-Z_\.]+]] = constfelt  11
 // CHECK-DAG: %[[NBETA:[0-9a-zA-Z_\.]+]] = neg %[[BETA]]
@@ -111,84 +107,9 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[A2:[0-9a-zA-Z_\.]+]] = readarr %[[A]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[A3:[0-9a-zA-Z_\.]+]] = readarr %[[A]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[B0:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[B1:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[B2:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[B3:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
-
-// CHECK-DAG: %[[BETA:[0-9a-zA-Z_\.]+]] = constfelt  11
-// CHECK-DAG: %[[NBETA:[0-9a-zA-Z_\.]+]] = neg %[[BETA]]
-
-// COM:         a[0] * b[0]
-// CHECK-DAG: %[[T0:[0-9a-zA-Z_\.]+]] = mul %[[A0]], %[[B0]]
-// COM:                                a[1] * b[3]
-// CHECK-DAG: %[[T1:[0-9a-zA-Z_\.]+]] = mul %[[A1]], %[[B3]]
-// COM:                                              a[2] * b[2]
-// CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = mul %[[A2]], %[[B2]]
-// COM:                                                            a[3] * b[1]
-// CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = mul %[[A3]], %[[B1]]
-// COM:                                a[1] * b[3] + a[2] * b[2]
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = add %[[T1]], %[[T2]]
-// COM:                                a[1] * b[3] + a[2] * b[2] + a[3] * b[1]
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = add %[[T4]], %[[T3]]
-// COM:                       NBETA * (a[1] * b[3] + a[2] * b[2] + a[3] * b[1])
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = mul %[[NBETA]], %[[T5]]
-// COM: out_0 = a[0] * b[0] + NBETA * (a[1] * b[3] + a[2] * b[2] + a[3] * b[1])
-// CHECK-DAG: %[[OUT0:[0-9a-zA-Z_\.]+]] = add %[[T0]], %[[T6]]
-
-// COM:         a[0] * b[1]
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = mul %[[A0]], %[[B1]]
-// COM:                       a[1] * b[0]
-// CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = mul %[[A1]], %[[B0]]
-// COM:                                              a[2] * b[3]
-// CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = mul %[[A2]], %[[B3]]
-// COM:                                                            a[3] * b[2]
-// CHECK-DAG: %[[T10:[0-9a-zA-Z_\.]+]] = mul %[[A3]], %[[B2]]
-// COM:                                              a[2] * b[3] + a[3] * b[2]
-// CHECK-DAG: %[[T11:[0-9a-zA-Z_\.]+]] = add %[[T9]], %[[T10]]
-// COM:                                     NBETA * (a[2] * b[3] + a[3] * b[2])
-// CHECK-DAG: %[[T12:[0-9a-zA-Z_\.]+]] = mul %[[NBETA]], %[[T11]]
-// COM:         a[0] * b[1] + a[1] * b[0]
-// CHECK-DAG: %[[T13:[0-9a-zA-Z_\.]+]] = add %[[T7]], %[[T8]]
-// COM: out_1 = a[0] * b[1] + a[1] * b[0] + NBETA * (a[2] * b[3] + a[3] * b[2])
-// CHECK-DAG: %[[OUT1:[0-9a-zA-Z_\.]+]] = add %[[T13]], %[[T12]]
-
-// COM:         a[0] * b[2]
-// CHECK-DAG: %[[T14:[0-9a-zA-Z_\.]+]] = mul %[[A0]], %[[B2]]
-// COM:                       a[1] * b[1]
-// CHECK-DAG: %[[T15:[0-9a-zA-Z_\.]+]] = mul %[[A1]], %[[B1]]
-// COM:                                     a[2] * b[0]
-// CHECK-DAG: %[[T16:[0-9a-zA-Z_\.]+]] = mul %[[A2]], %[[B0]]
-// COM:                                                            a[3] * b[3]
-// CHECK-DAG: %[[T17:[0-9a-zA-Z_\.]+]] = mul %[[A3]], %[[B3]]
-// COM:                                                   NBETA * (a[3] * b[3])
-// CHECK-DAG: %[[T18:[0-9a-zA-Z_\.]+]] = mul %[[NBETA]], %[[T17]]
-// COM:         a[0] * b[2] + a[1] * b[1]
-// CHECK-DAG: %[[T19:[0-9a-zA-Z_\.]+]] = add %[[T14]], %[[T15]]
-// COM:         a[0] * b[2] + a[1] * b[1] + a[2] * b[0]
-// CHECK-DAG: %[[T20:[0-9a-zA-Z_\.]+]] = add %[[T19]], %[[T16]]
-// COM: out_2 = a[0] * b[2] + a[1] * b[1] + a[2] * b[0] + NBETA * (a[3] * b[3])
-// CHECK-DAG: %[[OUT2:[0-9a-zA-Z_\.]+]] = add %[[T20]], %[[T18]]
-
-// COM:         a[0] * b[3]
-// CHECK-DAG: %[[T21:[0-9a-zA-Z_\.]+]] = mul %[[A0]], %[[B3]]
-// COM:                       a[1] * b[2]
-// CHECK-DAG: %[[T22:[0-9a-zA-Z_\.]+]] = mul %[[A1]], %[[B2]]
-// COM:                                     a[2] * b[1] 
-// CHECK-DAG: %[[T23:[0-9a-zA-Z_\.]+]] = mul %[[A2]], %[[B1]]
-// COM:                                                   a[3] * b[0]
-// CHECK-DAG: %[[T24:[0-9a-zA-Z_\.]+]] = mul %[[A3]], %[[B0]]
-// COM:         a[0] * b[3] + a[1] * b[2]
-// CHECK-DAG: %[[T25:[0-9a-zA-Z_\.]+]] = add %[[T21]], %[[T22]]
-// COM:         a[0] * b[3] + a[1] * b[2] + a[2] * b[1]
-// CHECK-DAG: %[[T26:[0-9a-zA-Z_\.]+]] = add %[[T25]], %[[T23]]
-// COM: out_3 = a[0] * b[3] + a[1] * b[2] + a[2] * b[1] + a[3] * b[0]
-// CHECK-DAG: %[[OUT3:[0-9a-zA-Z_\.]+]] = add %[[T26]], %[[T24]]
-
-// CHECK-DAG: %[[T27:[0-9a-zA-Z_\.]+]] = new_array %[[OUT0]], %[[OUT1]], %[[OUT2]], %[[OUT3]] : <4 x !llzk.felt>
+// CHECK-DAG: %[[B0:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B1:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B2:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[B3:[0-9a-zA-Z_\.]+]] = readarr %[[B]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
 }

--- a/tests/lit/zir/extval/sub_ext.zir
+++ b/tests/lit/zir/extval/sub_ext.zir
@@ -16,14 +16,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
 // CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = sub %[[T0]], %[[T4]] : !llzk.felt, !llzk.felt
 // CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = sub %[[T1]], %[[T5]] : !llzk.felt, !llzk.felt
@@ -45,22 +41,10 @@ component Foo(x: ExtVal, y: ExtVal) {
 // CHECK-DAG: %[[T2:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
 // CHECK-DAG: %[[T3:[0-9a-zA-Z_\.]+]] = readarr %[[A0]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
-// CHECK-DAG: %[[C4:[0-9a-zA-Z_\.]+]] = index.constant  0
-// CHECK-DAG: %[[C5:[0-9a-zA-Z_\.]+]] = index.constant  1
-// CHECK-DAG: %[[C6:[0-9a-zA-Z_\.]+]] = index.constant  2
-// CHECK-DAG: %[[C7:[0-9a-zA-Z_\.]+]] = index.constant  3
-// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C4]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C5]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C6]]] : <4 x !llzk.felt>, !llzk.felt
-// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C7]]] : <4 x !llzk.felt>, !llzk.felt
-
-// CHECK-DAG: %[[T8:[0-9a-zA-Z_\.]+]] = sub %[[T0]], %[[T4]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T9:[0-9a-zA-Z_\.]+]] = sub %[[T1]], %[[T5]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T10:[0-9a-zA-Z_\.]+]] = sub %[[T2]], %[[T6]] : !llzk.felt, !llzk.felt
-// CHECK-DAG: %[[T11:[0-9a-zA-Z_\.]+]] = sub %[[T3]], %[[T7]] : !llzk.felt, !llzk.felt
-
-// CHECK-DAG: %[[T12:[0-9a-zA-Z_\.]+]] = new_array %[[T8]], %[[T9]], %[[T10]], %[[T11]] : <4 x !llzk.felt>
-
+// CHECK-DAG: %[[T4:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C0]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T5:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C1]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T6:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C2]]] : <4 x !llzk.felt>, !llzk.felt
+// CHECK-DAG: %[[T7:[0-9a-zA-Z_\.]+]] = readarr %[[A1]][%[[C3]]] : <4 x !llzk.felt>, !llzk.felt
 
   ExtSub(x, y)
 }

--- a/tests/lit/zir/extval/write_into_arr.zir
+++ b/tests/lit/zir/extval/write_into_arr.zir
@@ -14,11 +14,7 @@ component Foo(x: ExtVal) {
 
 // CHECK: scf.for 
 // CHECK-SAME:    %[[A1:[0-9a-zA-Z_\.]+]] = %{{[0-9a-zA-Z_\.]+}} to %{{[0-9a-zA-Z_\.]+}} step %{{[0-9a-zA-Z_\.]+}}
-// CHECK-SAME:    iter_args(%[[A2:[0-9a-zA-Z_\.]+]] = %[[T0]]) -> (!llzk.array<9,4 x !llzk.felt>) {
-// CHECK: %[[T1:[0-9a-zA-Z_\.]+]] = scf.execute_region -> !llzk.array<4 x !llzk.felt> {
-// CHECK: scf.yield %[[A0]] : !llzk.array<4 x !llzk.felt>
-// CHECK: llzk.insertarr %[[A2]][%[[A1]]] = %[[T1]] : <9,4 x !llzk.felt>, <4 x !llzk.felt>
-// CHECK: scf.yield %[[A2]] : !llzk.array<9,4 x !llzk.felt>
+// CHECK: llzk.insertarr %[[T0]][%[[A1]]] = %[[A0]] : <9,4 x !llzk.felt>, <4 x !llzk.felt>
 // CHECK: writef %[[SELF]][@"$array"] = %[[T0]] : <@Foo<[]>>, !llzk.array<9,4 x !llzk.felt>
 // CHECK: %[[T2:[0-9a-zA-Z_\.]+]] = readf %[[SELF]][@"$array"] : <@Foo<[]>>, !llzk.array<9,4 x !llzk.felt>
 // CHECK: writef %[[SELF]][@"$super"] = %[[T2]] : <@Foo<[]>>, !llzk.array<9,4 x !llzk.felt>

--- a/tests/lit/zir/member_array.zir
+++ b/tests/lit/zir/member_array.zir
@@ -11,8 +11,8 @@ component Bar() {
   f.bits[0]
 
 // CHECK-LABEL: func @compute() -> !llzk.struct<@Bar<[]>> {
-// CHECK:     %[[T0:[0-9a-zA-Z_\.]+]] = new_struct : <@Bar<[]>>
 // CHECK:     %[[T1:[0-9a-zA-Z_\.]+]] = constfelt  2
+// CHECK:     %[[T0:[0-9a-zA-Z_\.]+]] = new_struct : <@Bar<[]>>
 // CHECK:     %[[T2:[0-9a-zA-Z_\.]+]] = call @Foo::@compute(%[[T1]]) : (!llzk.felt) -> !llzk.struct<@Foo<[]>> 
 // CHECK:     writef %[[T0]][@f] = %[[T2]] : <@Bar<[]>>, !llzk.struct<@Foo<[]>>
 // CHECK:     %[[T3:[0-9a-zA-Z_\.]+]] = readf %[[T0]][@f] : <@Bar<[]>>, !llzk.struct<@Foo<[]>>

--- a/tests/lit/zir/unpack-non-known-const.zir
+++ b/tests/lit/zir/unpack-non-known-const.zir
@@ -20,13 +20,13 @@ component User1<N: Val, P: Val>() {
 // CHECK-DAG:     %[[T2:[0-9a-zA-Z_\.]+]] = read_const @P : !llzk.felt
 // CHECK-DAG:     %[[T3:[0-9a-zA-Z_\.]+]] = toindex %[[T2]]
 // CHECK-DAG:     %[[T4:[0-9a-zA-Z_\.]+]] = new_array{()[%[[T1]], %[[T3]]]} : <#[[MAP:[0-9a-zA-Z_\.]+]] x !llzk.felt>
-// CHECK-DAG:     %[[T10:[0-9a-zA-Z_\.]+]]  = scf.for %{{[0-9a-zA-Z_\.]+}} = %{{[0-9a-zA-Z_\.]+}} to %{{[0-9a-zA-Z_\.]+}} step %{{[0-9a-zA-Z_\.]+}} iter_args(%{{[0-9a-zA-Z_\.]+}} = %[[T4:[0-9a-zA-Z_\.]+]]) -> (!llzk.array<#[[MAP]] x !llzk.felt>) {
+// CHECK-DAG:     scf.for %{{[0-9a-zA-Z_\.]+}} = %{{[0-9a-zA-Z_\.]+}} to %{{[0-9a-zA-Z_\.]+}} step %{{[0-9a-zA-Z_\.]+}} {
 
 // CHECK-DAG:     %[[T5:[0-9a-zA-Z_\.]+]] = read_const @N : !llzk.felt
 // CHECK-DAG:     %[[T6:[0-9a-zA-Z_\.]+]] = toindex %[[T5]]
 // CHECK-DAG:     %[[T7:[0-9a-zA-Z_\.]+]] = read_const @P : !llzk.felt
 // CHECK-DAG:     %[[T8:[0-9a-zA-Z_\.]+]] = toindex %[[T7]]
-// CHECK-DAG:     %[[T9:[0-9a-zA-Z_\.]+]] = call @Unpack::@compute(%[[T10]]) {()[%[[T6]], %[[T8]]]} : (!llzk.array<#[[MAP]] x !llzk.felt>) -> !llzk.struct<@Unpack<[@N, @P, #[[MAP]]]>>
+// CHECK-DAG:     %[[T9:[0-9a-zA-Z_\.]+]] = call @Unpack::@compute(%[[T4]]) {()[%[[T6]], %[[T8]]]} : (!llzk.array<#[[MAP]] x !llzk.felt>) -> !llzk.struct<@Unpack<[@N, @P, #[[MAP]]]>>
 
 // CHECK-LABEL: func @constrain(%{{[0-9a-zA-Z_\.]+}}: !llzk.struct<@User1<[@N, @P]>>) {
 }


### PR DESCRIPTION
This PR enables the cleanup by default. No tests were failing with these enabled, only FileCheck diffs.