### PR TITLE
move ASAN_OPTIONS setting to the nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,11 @@
 
               # For using mlir-tblgen inside the dev environment
               export LD_LIBRARY_PATH=${pkgs.z3.lib}/lib:$LD_LIBRARY_PATH
+
+              # Disable container overflow checks because it can give false positives in
+              # ConvertZmlToLlzkPass::runOnOperation() since LLVM itself is not built with ASan.
+              # https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
+              export ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0
             '';
           });
 

--- a/tests/lit/lit.cfg.py
+++ b/tests/lit/lit.cfg.py
@@ -7,11 +7,6 @@ from lit.llvm.subst import ToolSubst
 
 config.name = "zklang"
 
-# Disable container overflow checks because it can give false positives in
-# ConvertZmlToLlzkPass::runOnOperation() since LLVM itself is not built with ASan.
-# https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
-config.environment["ASAN_OPTIONS"] = "detect_container_overflow=0:detect_leaks=0"
-
 # Configuration file for the 'lit' test runner.
 config.test_format = formats.ShTest(True)
 


### PR DESCRIPTION
Set it for the shell so it applies to executing `zklang` directly rather than only applying to running the lit test suite.