### PR TITLE
Increase timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: "Build"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ ubuntu-24.04 ]


### PR DESCRIPTION
CI hits the 10 minute timeout pretty often so for the time being lets have it at 20 minutes
