### PR TITLE
add git to nix shell

### DIFF
--- a/changelogs/unreleased/th__add-git-to-nix.yaml
+++ b/changelogs/unreleased/th__add-git-to-nix.yaml
@@ -1,0 +1,2 @@
+added:
+  - support git in the nix shell

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
           default =  pkgs.zklang.overrideAttrs (old: {
             nativeBuildInputs = (with pkgs; [
               doxygen
+              git
 
               # clang-tidy and clang-format
               clang-tools_18


### PR DESCRIPTION
The doxygen configuration step uses git so it must be loaded in the nix shell